### PR TITLE
update project details for TUF

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,14 +1,14 @@
  project:
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/tuf/icon/color/tuf-icon-color.svg?sanitize=true"
-  display_name: The Update Framework (TUF)
-  sub_title: A framework for securing software update systems
+  display_name: TUF
+  sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
-  stable_ref: "v0.12.0"
+  stable_ref: "tuf v0.12.1"
   head_ref: "master"
   ci_system:
     -
       ci_system_type: "travis-ci"
-      ci_project_url: "https://example.com/theupdateframework/tuf"  # can be anything for citest
+      ci_project_url: "https://travis-ci.org/theupdateframework/tuf"
       ci_project_name: "theupdateframework/tuf"
       arch:
         - amd64


### PR DESCRIPTION
project details should match what is displayed on https://www.cncf.io/projects/ 
- I changed the display name and the subtitle

ci_project_url should not say "example" # can be anything 
- I added the actual CI URL https://travis-ci.org/theupdateframework/tuf
- I removed the comment # can be anything  

## Description
1. update project details for TUF
   a. Change display name to match wording on  https://www.cncf.io/projects/
   b. Change subtitle to match wording on https://www.cncf.io/projects/
   c. Change ci_project_url from `example.com` to `"https://travis-ci.org/theupdateframework/tuf"`
   d. remove comment `# can be anything`  

## Issues:
- https://github.com/crosscloudci/crosscloudci/issues/217
- https://github.com/vulk/cncf_ci/issues/319

## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against
   * [ ] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [ ]  Browser tested on staging.cncf.ci
* [x]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
* [x]  My change requires a change to the documentation. 
> Suggestions: to re-use the display name and sub-title from https://www.cncf.io/projects/, to add the project's actual CI system URL, remove the note `# can be anything for citest` from the docs and all project configuration repos
* [ ]  I have updated the documentation accordingly.
* [ ] No updates required.