### PR TITLE
Update Stable to v0.12.2 on dev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: TUF
   sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
-  stable_ref: "v0.12.0"
+  stable_ref: "v0.12.2"
   head_ref: "develop"
   ci_system:
     -


### PR DESCRIPTION

## Description
 - v0.12.2 was released on 01-10-2020
 - update stable on dev

## Issues:

https://github.com/vulk/cncf_ci/issues/342

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [ ]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [ ]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
