### PR TITLE
Update cncfci.yml to correct head ref

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
   stable_ref: "v0.12.2"
-  head_ref: "master"
+  head_ref: "develop"
   ci_system:
     -
       ci_system_type: "travis-ci"


### PR DESCRIPTION
so it turns out.... tuf doesn't have a master branch o.o

https://github.com/theupdateframework/tuf/branches/all