### PR TITLE
Enable v0.12.2 to production

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,7 +8,7 @@
   ci_system:
     -
       ci_system_type: "travis-ci"
-      ci_project_url: "https://example.com/theupdateframework/tuf"  # can be anything for citest
+      ci_project_url: "https://travis-ci.org/theupdateframework/tuf"  
       ci_project_name: "theupdateframework/tuf"
       arch:
         - amd64

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
   stable_ref: "v0.12.2"
-  head_ref: "master"
+  head_ref: "develop"
   ci_system:
     -
       ci_system_type: "travis-ci"

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: TUF
   sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
-  stable_ref: "v0.12.0"
+  stable_ref: "v0.12.2"
   head_ref: "develop"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
   stable_ref: "v0.12.0"
-  head_ref: "master"
+  head_ref: "develop"
   ci_system:
     -
       ci_system_type: "travis-ci"

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,14 +1,14 @@
  project:
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/tuf/icon/color/tuf-icon-color.svg?sanitize=true"
-  display_name: The Update Framework (TUF)
-  sub_title: A framework for securing software update systems
+  display_name: TUF
+  sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
-  stable_ref: "v0.12.0"
+  stable_ref: "tuf v0.12.1"
   head_ref: "master"
   ci_system:
     -
       ci_system_type: "travis-ci"
-      ci_project_url: "https://example.com/theupdateframework/tuf"  # can be anything for citest
+      ci_project_url: "https://travis-ci.org/theupdateframework/tuf"
       ci_project_name: "theupdateframework/tuf"
       arch:
         - amd64


### PR DESCRIPTION
## Description

- v0.12.2 was released on 01-10-2020
- update stable on production

## Issues:

https://github.com/vulk/cncf_ci/issues/342

How Has This Been Tested?
---
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested with trigger client against
  - [ ]  cidev.cncf.ci
  - [ ]  dev.cncf.ci
  - [x]  staging.cncf.ci
  - [ ]  cncf.ci (production)
- [ ] Browser tested on staging.cncf.ci
- [ ] Manually tested on https://gitlab.dev.cncf.ci web ui - Build Succeeded
- [ ] Have not tested

Types of changes:
---
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Version update

Checklist:
---
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required
