### PR TITLE
Update TUF stable v0.13.0 on staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ compile:
 
       elif [ "$BASE_URL" == "https://gitlab.cidev.cncf.ci" ]; then
         echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH"
-        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}}&arch=$ARCH" 
+        curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH" 
 
       else
         echo curl -f -X GET "https://devapi.cncf.ci/ciproxy/v1/ci_status_build/commit_ref?project=${CI_PROJECT_NAME}&ref=${CI_COMMIT_SHA}&arch=$ARCH"

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: TUF
   sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
-  stable_ref: "v0.12.2"
+  stable_ref: "v0.13.0"
   head_ref: "develop"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
   stable_ref: "v0.12.2"
-  head_ref: "master"
+  head_ref: "develop"
   ci_system:
     -
       ci_system_type: "travis-ci"


### PR DESCRIPTION
## Description

- v0.13.0 was released on 08-04-2020
- update stable on staging
- passed dev trigger build: https://gitlab.dev.cncf.ci/theupdateframework/tuf/-/jobs/201902

## Issues:

https://github.com/vulk/cncf_ci/issues/342

How Has This Been Tested?
---
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested with trigger client against
  - [ ]  cidev.cncf.ci
  - [x]  dev.cncf.ci
  - [ ]  staging.cncf.ci
  - [ ]  cncf.ci (production)
- [ ] Browser tested on staging.cncf.ci
- [x] Manually tested on https://gitlab.dev.cncf.ci web ui - Build Succeeded
- [ ] Have not tested

Types of changes:
---
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Version update

Checklist:
---
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required
