### PR TITLE
Update Stable to v0.15.0 on production

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: TUF
   sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
-  stable_ref: "v0.14.0"
+  stable_ref: "v0.15.0"
   head_ref: "develop"
   ci_system:
     -


### PR DESCRIPTION
## Description
  - v0.15.0 was released on 10/23/2020
  - update stable on production
  - passes manual pipeline and trigger build: https://gitlab.staging.cncf.ci/theupdateframework/tuf/-/jobs/201077

 https://github.com/vulk/cncf_ci/issues/342

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [x]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
