### PR TITLE
Update TUF stable to v0.16.0 on staging

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,7 +8,7 @@
   ci_system:
     -
       ci_system_type: "travis-ci-com"
-      ci_project_url: "https://travis-ci.org/theupdateframework/tuf"
+      ci_project_url: "https://travis-ci.com/theupdateframework/tuf"
       ci_project_name: "theupdateframework/tuf"
       arch:
         - amd64

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: TUF
   sub_title: Software Update Spec
   project_url: "https://github.com/theupdateframework/tuf"
-  stable_ref: "v0.15.0"
+  stable_ref: "v0.16.0"
   head_ref: "develop"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -7,7 +7,7 @@
   head_ref: "develop"
   ci_system:
     -
-      ci_system_type: "travis-ci"
+      ci_system_type: "travis-ci-com"
       ci_project_url: "https://travis-ci.org/theupdateframework/tuf"
       ci_project_name: "theupdateframework/tuf"
       arch:


### PR DESCRIPTION

## Description
  - v0.16.0 was released on 11/26/2020
  - update stable on staging
  - updates travis-ci-com to use travis-ci.com instead of .org as it's been deprecated
  - passed trigger builds https://gitlab.dev.cncf.ci/theupdateframework/tuf/-/jobs/205088

## Issues:

 https://github.com/vulk/cncf_ci/issues/342

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x]  Tested with trigger client against
   - [x]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
